### PR TITLE
Add more Spanish aliases

### DIFF
--- a/spanish-gitconfig
+++ b/spanish-gitconfig
@@ -4,13 +4,17 @@
   clonar = clone
   control = remote
   culpar = blame
+  dife = diff
   empujar = push
   eneso = init
   estado = status
+  etiquetar = tag
   guardar = stash
   inic = init
+  mostrar = show
   perpetrar = commit
   rama = branch
+  restablecer = reset
   revertir = revert
   revisar = checkout
   tirar = pull

--- a/spanish-gitconfig
+++ b/spanish-gitconfig
@@ -2,9 +2,9 @@
   agregar = add
   bitacora = log
   clonar = clone
-  control = remote
   culpar = blame
   dife = diff
+  distante = remote
   empujar = push
   eneso = init
   estado = status

--- a/spanish-gitconfig
+++ b/spanish-gitconfig
@@ -2,13 +2,17 @@
   agregar = add
   bitacora = log
   clonar = clone
+  control = remote
   culpar = blame
   empujar = push
+  eneso = init
   estado = status
   guardar = stash
+  inic = init
   perpetrar = commit
   rama = branch
   revertir = revert
+  revisar = checkout
   tirar = pull
   tronco = log
   unir = merge


### PR DESCRIPTION
First of all, thank you for this incredibly useful project!

Upon installing and using this config, i noticed that a couple of git commands i frequently use were missing Spanish aliases, and reverting to English was incredibly sad. This PR is an attempt at remedying that :relaxed: 

Some notes on the chosen aliases:
- I've never understood if `init` it means "in it" (which is totally reasonable for creating a repository where you're gonna "put things _in it_") or if it is an abbreviation of "initialize". So i added two aliases to cover both meanings (similar to `tronco = log`)
- I first considered using `relojear` for `checkout`, which i think would be the most appropriate translation for Argentinian users (e.g, "hey, were you _checking out_ my parner?" -> "che ¿estabas _relojeando_ a mi pareja?"). But it was most likely going to confuse other Hispanic people, so i left the more neutral `revisar`.
    
    Maybe we could have an `es-AR-gitconfig` file that includes the aliases from the base Spanish config and adds its own Argentinian slang words (e.g., `encanutar = stash`, `arrugar = revert`). What do you think?

Cheers!