### PR TITLE
Avoid hypocrisy by translating the git command itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Add this to your `.gitconfig`, using your own absolute path to the localized git
 
 ```
 
+Then add the following line to your `~/.bashrc` file. `zsh` is not supported yet.
+
+```
+source /path/to/gitconfig-i18n/locales/ES-es.bashrc
+```
+
 Now you enjoy the following aliases. You're welcome.
 
 ```
@@ -46,11 +52,11 @@ There's a more Argentina-specific [.gitconfig](https://github.com/lucasefe/gitco
 ## Example
 
 ```
-$ git tirar
+$ cretino tirar
 $ vim README.md
-$ git agregar README.md
-$ git perpetrar -am "Readme updated"
-$ git empujar
+$ cretino agregar README.md
+$ cretino perpetrar -am "Readme updated"
+$ cretino empujar
 ```
 
 ## Wanna contribute?

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Now you can change those commands and let the discussion be over. No more excuse
 
 ## Install
 
-Add this to your `.gitconfig`, using the your own absolute path to the localized .gitconfig file.
+Add this to your `.gitconfig`, using your own absolute path to the localized gitconfig file.
 
 ```
 [include]

--- a/locales/ES-es.bashrc
+++ b/locales/ES-es.bashrc
@@ -1,0 +1,1 @@
+alias cretino='git'

--- a/test/main.bats
+++ b/test/main.bats
@@ -1,6 +1,7 @@
 #!./libs/bats/bin/bats
 
 MAIN_FILE='./locales/ES-es.gitconfig'
+BASH_RC='./locales/ES-es.bashrc'
 
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
@@ -72,4 +73,9 @@ load 'libs/bats-assert/load'
 @test "unir should be an alias of merge" {
     run cat $MAIN_FILE
     assert_line --regexp '^  unir = merge$'
+}
+
+@test "cretino should be an alias of git itself" {
+    run cat $BASH_RC
+    assert_output --regexp 'cretino=.git.'
 }


### PR DESCRIPTION
## Defect

I couldn't help but notice the hypocrisy behind translating git subcommands while not translating the git command itself.

This PR is an attempt to solve this problem.

## Proposed solution

Implement an alias for git. Currently tested on bash.
